### PR TITLE
Added hidden to OrcaType and OrcaPod

### DIFF
--- a/WhaleSpotting/react-app/src/components/Card.tsx
+++ b/WhaleSpotting/react-app/src/components/Card.tsx
@@ -27,8 +27,8 @@ export default function Card({ sighting, admin = false }: CardProps): JSX.Elemen
                         <div>Reported By: {sighting.username} </div>
                     </div>
                     <div data-testid="second-column" className={closeCard ? "second-column closed" : "second-column open"}>
-                        <div>Orca type: {sighting.orcaType}</div>
-                        <div>Orca pod: {sighting.orcaPod}</div>
+                        <div data-testid="orca-type" hidden={!(sighting.species=="Orca")}>Orca type: {sighting.orcaType}</div>
+                        <div data-testid="orca-pod" hidden={!(sighting.orcaType=="SouthernResident")}>Orca pod: {sighting.orcaPod}</div>
                         <div>Longitude: {sighting.longitude} </div>
                         <div>Latitude: {sighting.latitude} </div>
                         <div>Description: {sighting.description} </div>

--- a/WhaleSpotting/react-app/src/components/Card.tsx
+++ b/WhaleSpotting/react-app/src/components/Card.tsx
@@ -27,8 +27,8 @@ export default function Card({ sighting, admin = false }: CardProps): JSX.Elemen
                         <div>Reported By: {sighting.username} </div>
                     </div>
                     <div data-testid="second-column" className={closeCard ? "second-column closed" : "second-column open"}>
-                        <div data-testid="orca-type" hidden={!(sighting.species=="Orca")}>Orca type: {sighting.orcaType}</div>
-                        <div data-testid="orca-pod" hidden={!(sighting.orcaType=="SouthernResident")}>Orca pod: {sighting.orcaPod}</div>
+                        <div data-testid="orca-type" hidden={sighting.species !== "Orca"}>Orca type: {sighting.orcaType}</div>
+                        <div data-testid="orca-pod" hidden={sighting.orcaType !== "SouthernResident"}>Orca pod: {sighting.orcaPod}</div>
                         <div>Longitude: {sighting.longitude} </div>
                         <div>Latitude: {sighting.latitude} </div>
                         <div>Description: {sighting.description} </div>

--- a/WhaleSpotting/react-app/src/tests/components/Card.test.tsx
+++ b/WhaleSpotting/react-app/src/tests/components/Card.test.tsx
@@ -8,13 +8,13 @@ import { confirmSighting } from "../../api/apiClient";
 const exampleConfirmed: SightingApiModel = {
     id: 1,
     sightedAt: new Date().toDateString(),
-    species: "orca",
+    species: "Something else",
     quantity: 3,
     location: "Sea",
     longitude: 1.232,
     latitude: 2.312,
     description: "Whales at sea",
-    orcaType: "Orca",
+    orcaType: "Not known",
     orcaPod: "",
     confirmed: true,
     username: "FakeUserConfirmed"
@@ -23,7 +23,7 @@ const exampleConfirmed: SightingApiModel = {
 const exampleUnconfirmed: SightingApiModel = {
     id: 2,
     sightedAt: new Date().toDateString(),
-    species: "orca",
+    species: "Orca",
     quantity: 3,
     location: "Sea",
     longitude: 1.232,
@@ -31,6 +31,21 @@ const exampleUnconfirmed: SightingApiModel = {
     description: "Whales at sea",
     orcaType: "Orca",
     orcaPod: "",
+    confirmed: false,
+    username: "FakeUserNotConfirmed"
+};
+
+const orcaSouthen: SightingApiModel = {
+    id: 2,
+    sightedAt: new Date().toDateString(),
+    species: "Orca",
+    quantity: 3,
+    location: "Sea",
+    longitude: 1.232,
+    latitude: 2.312,
+    description: "Whales at sea",
+    orcaType: "SouthernResident",
+    orcaPod: "j",
     confirmed: false,
     username: "FakeUserNotConfirmed"
 };
@@ -99,6 +114,25 @@ test("On click of approve confirmSighting API is called", () => {
 
     setTimeout(() => {
         expect(confirmSighting).toBeCalled();
-    }, 100);
-    
+    }, 100); 
+});
+
+test("OrcaType is hidden for species not Orca", () => {
+    render(<Card sighting={exampleConfirmed} admin={true} />);
+    const orcaType = screen.getByTestId("orca-type");
+    expect(orcaType).toHaveAttribute("hidden");
+});
+
+test("OrcaPod is hidden if OrcaType is not SouthernResident", () => {
+    render(<Card sighting={exampleUnconfirmed} admin={true} />);
+    const orcaPod = screen.getByTestId("orca-pod");
+    expect(orcaPod).toHaveAttribute("hidden");
+});
+
+test("OrcaPod and OrcaType are not hidden for Orca SouthernResident", () => {
+    render(<Card sighting={orcaSouthen} admin={true} />);
+    const orcaType = screen.getByTestId("orca-type");
+    expect(orcaType).not.toHaveAttribute("hidden");
+    const orcaPod = screen.getByTestId("orca-type");
+    expect(orcaPod).not.toHaveAttribute("hidden");
 });


### PR DESCRIPTION
OrcaTYpe is hidden when species is not Orca
OrcaPod is hidden when OrcaType is not SouththenResident (as on WhaleMuseum Api)
![image](https://user-images.githubusercontent.com/84719941/129175128-458679a8-1430-4447-8b82-0b4b1d989b5e.png)
![image](https://user-images.githubusercontent.com/84719941/129175206-a2fce59f-2cd8-4db6-aa62-dfc07d096946.png)
