### PR TITLE
GetAllSightings returns confirmed only and Search is ordered Desending

### DIFF
--- a/WhaleSpotting.UnitTests/Services/SightingsServiceTests.cs
+++ b/WhaleSpotting.UnitTests/Services/SightingsServiceTests.cs
@@ -24,22 +24,25 @@ namespace WhaleSpotting.UnitTests.Services
         }
 
         [Fact]
-        public async Task GetAllSightings_Called_ReturnsSightings()
+        public async Task GetAllSightings_Called_ReturnsConfirmedSightings()
         {
             // Arrange
             var sightings = new List<SightingDbModel>
             {
                 new SightingDbModel
                 {
-                    Id = 1
+                    Id = 1,
+                    Confirmed = true
                 },
                 new SightingDbModel
                 {
-                    Id = 2
+                    Id = 2,
+                    Confirmed = true
                 },
                 new SightingDbModel
                 {
-                    Id = 3
+                    Id = 3,
+                    Confirmed = false
                 }
             };
 
@@ -50,7 +53,7 @@ namespace WhaleSpotting.UnitTests.Services
             var result = await _underTest.GetAllSightings();
 
             // Assert
-            result.Should().HaveCount(3);
+            result.Should().HaveCount(2);
         }
 
         [Fact]
@@ -100,7 +103,8 @@ namespace WhaleSpotting.UnitTests.Services
                 Quantity = 5,
                 Description = "Whales at sea",
                 SightedAt = DateTime.Now,
-                User = user
+                User = user,
+                Confirmed = true
             };
 
             await Context.Sightings.AddAsync(whaleSighting);

--- a/WhaleSpotting/Services/SightingsService.cs
+++ b/WhaleSpotting/Services/SightingsService.cs
@@ -38,7 +38,7 @@ namespace WhaleSpotting.Services
             var sightings = await _context.Sightings
                 .Where(s => s.Confirmed)
                 .Include(s => s.User)
-                .OrderBy(s => s.SightedAt)
+                .OrderByDescending(s => s.SightedAt)
                 .Select(s => new SightingResponseModel(s))
                 .ToListAsync();
 
@@ -118,7 +118,7 @@ namespace WhaleSpotting.Services
             var sightings = await _context.Sightings
                 .Where(s => s.Confirmed == false)
                 .Include(s => s.User)
-                .OrderBy(s => s.SightedAt)
+                .OrderByDescending(s => s.SightedAt)
                 .Skip((pageFilter.PageNumber - 1) * pageFilter.PageSize)
                 .Take(pageFilter.PageSize)
                 .Select(s => new SightingResponseModel(s))
@@ -182,6 +182,7 @@ namespace WhaleSpotting.Services
             var sightings = await _context.Sightings
                 .Include(s => s.User)
                 .Where(s => s.User.Id == currentUser.Id)
+                .OrderByDescending(s => s.CreatedAt)
                 .Skip((pageFilter.PageNumber - 1) * pageFilter.PageSize)
                 .Take(pageFilter.PageSize)
                 .Select(s => new SightingResponseModel(s))

--- a/WhaleSpotting/Services/SightingsService.cs
+++ b/WhaleSpotting/Services/SightingsService.cs
@@ -36,6 +36,7 @@ namespace WhaleSpotting.Services
         public async Task<List<SightingResponseModel>> GetAllSightings()
         {
             var sightings = await _context.Sightings
+                .Where(s => s.Confirmed)
                 .Include(s => s.User)
                 .OrderBy(s => s.SightedAt)
                 .Select(s => new SightingResponseModel(s))
@@ -54,7 +55,7 @@ namespace WhaleSpotting.Services
                 .Where(s => string.IsNullOrEmpty(searchSighting.Location) || s.Location == searchSighting.Location)
                 .Where(s => searchSighting.Confirmed == null || s.Confirmed == searchSighting.Confirmed)
                 .Include(s => s.User)
-                .OrderBy(s => s.SightedAt)
+                .OrderByDescending(s => s.SightedAt)
                 .Skip((pageFilter.PageNumber - 1) * pageFilter.PageSize)
                 .Take(pageFilter.PageSize)
                 .Select(s => new SightingResponseModel(s))


### PR DESCRIPTION
https://trello.com/c/zv0Vmcsx/83-reverse-ordering-by-date-on-get-sightings-endpoints
and
https://trello.com/c/ybkpdOqT/84-make-getallsightings-only-return-confirmed-sightings